### PR TITLE
fix: remove workflow dry-run and push main trigger

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -2,9 +2,6 @@ name: Publish Package to npmjs
 on:
     release:
         types: [published]
-    push:
-        branches:
-            - main
 jobs:
     build:
         runs-on: ubuntu-latest
@@ -24,6 +21,6 @@ jobs:
             - run: npm ci
 
             # Publish to npm
-            - run: npm publish --provenance --access public --dry-run
+            - run: npm publish --provenance --access public
               env:
                   NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ierky/coingecko-angular",
-  "version": "1.0.1",
+  "version": "1.0.3",
   "description": "Coingecko api wrapper generated with openapi-generator typescript-angular",
   "main": "index.js",
   "scripts": {
@@ -20,7 +20,7 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/iErKy/coingecko-angular"
+    "url": "git+https://github.com/iErKy/coingecko-angular.git"
   },
   "homepage": "https://github.com/iErKy/coingecko-angular",
   "bugs": {


### PR DESCRIPTION
Remove dry-run flag in npm-publish workflow file together with push main trigger which was set for checking if it worked.